### PR TITLE
adiciona logica do displayName à função de cadastrar com email e senha

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -5,6 +5,7 @@ import {
   signInWithPopup,
   GoogleAuthProvider,
   sendPasswordResetEmail,
+  updateProfile,
 } from 'https://www.gstatic.com/firebasejs/9.10.0/firebase-auth.js'; //eslint-disable-line
 
 import { app } from './firebase-configuration.js';
@@ -14,8 +15,21 @@ import { app } from './firebase-configuration.js';
 const auth = getAuth(app);
 const provider = new GoogleAuthProvider(app);
 
-export function registerWithEmailAndPassword(email, password) {
-  return createUserWithEmailAndPassword(auth, email, password);
+export function registerWithEmailAndPassword(name, email, password) {
+  return createUserWithEmailAndPassword(auth, email, password)
+    .then((userCredential) => {
+      const user = userCredential.user;
+      console.log(user);
+      return user;
+    })
+    .then(() => {
+      updateProfile(auth.currentUser, {
+        displayName: name,
+      });
+    })
+    .catch((error) => {
+      console.log(error);
+    });
 }
 
 export function loginWithEmailAndPassword(email, password) {

--- a/src/pages/register/main.js
+++ b/src/pages/register/main.js
@@ -32,20 +32,21 @@ export default () => {
   const returnBtn = registerContainer.querySelector('#return-btn');
   returnBtn.addEventListener('click', () => window.location.replace('#homepage'));
 
-  const inputPassword = registerContainer.querySelector('#password-register');
+  const inputName = registerContainer.querySelector('#name-input');
   const inputEmail = registerContainer.querySelector('#register-input');
+  const inputPassword = registerContainer.querySelector('#password-register');
+  // const inputConfirmPassword = registerContainer.querySelector('#password-register-confirm');
   const btnRegister = registerContainer.querySelector('.btn-register');
   const btnGoogleRegister = registerContainer.querySelector('.btn-google-register');
 
   btnRegister.addEventListener('click', () => {
-    registerWithEmailAndPassword(inputEmail.value, inputPassword.value)
-      .then((userCredential) => {
-        const user = userCredential.user;
+    registerWithEmailAndPassword(inputName.value, inputEmail.value, inputPassword.value)
+      .then(() => {
         window.location.hash = '#feed';
-        return user;
       })
       .catch((/* error */) => {
-        /* const errorCode = error.code;
+      /* aqui a gente trata os erros por ex campo vazio ou senha menor que 6 digitos
+      const errorCode = error.code;
         const errorMessage = error.message; */
       });
   });


### PR DESCRIPTION
Gente, eu voltei pra seguir a função de cadastrar do jeito que tava no firebase. Por isso troquei de novo o objeto userCredential de arquivo, deixando ele no index.

Me dei conta de que ele é parte da lógica "por trás" do dom, pq a gente precisa de um return praquele then, - se o then der certo, o usuário é autenticado e completa o cadastro - e isso já faz parte da função assim que ela for chamada recebendo os argumentos do DOM (os values dos inputs), assim o firebase autentica conforme os values que digitamos nos inputs de cadastro. e quando a função é chamada no main.js da pagina de registro,  aquele then só significa que, se tiver tudo certo com a autenticação, o usuario então vai entrar no feed
se tiver algo de errado, ai temos que tratar os erros com o catch. o firebase dá alguns erros mas eles tem nomes como "auth/email-already-in-use" por exemplo (nao lembro se é exatamente escrito assim mas é algo do tipo), isso pra quando o email já foi cadastrado, ai é só a gente trocar a mensagem de erro de acordo com o tipo de erro que o firebase devolve. imagino que seja um if identificando qual mensagem de erro o firebase usou e se isso for true, retorna um innerhtml/innertext pra imprimir aquelas mensagens em textinho vermelho (ai precisaremos criar uma div nova no html pra esse campo).

enfim, me avisem se tiver tranquilo pra entender, e qualquer coisa nos falamos mais tbm! 