### PR TITLE
Fix/about listeners

### DIFF
--- a/src/pages/about/main.js
+++ b/src/pages/about/main.js
@@ -26,7 +26,7 @@ export default () => {
   const returnBtnDesktop = aboutContainer.querySelector('.return-button-desktop');
 
   [returnBtn, returnBtnDesktop].forEach((btn) => {
-    btn.addEventListener('click', () => window.location.replace('#homepage'));
+    btn.addEventListener('click', () => window.history.back());
   });
 
   return aboutContainer;

--- a/src/pages/login/main.js
+++ b/src/pages/login/main.js
@@ -86,5 +86,6 @@ export default () => {
     loginWithGoogle()
       .catch((error) => error);
   });
+
   return loginContainer;
 };

--- a/src/pages/login/main.js
+++ b/src/pages/login/main.js
@@ -58,7 +58,7 @@ export default () => {
   const firebaseWarningMessages = loginContainer.querySelector('#firebase-warning-messages');
   const returnBtn = loginContainer.querySelector('#return-btn');
 
-  returnBtn.addEventListener('click', () => window.location.replace('#homepage'));
+  returnBtn.addEventListener('click', () => window.history.back());
 
   btnLogin.addEventListener('click', () => {
     const formValidation = validateLoginForm(email.value, password.value);

--- a/src/pages/register/main.js
+++ b/src/pages/register/main.js
@@ -68,7 +68,7 @@ export default () => {
   const firebaseWarningMessages = registerContainer.querySelector('#firebase-warning-messages');
   const returnBtn = registerContainer.querySelector('#return-btn');
 
-  returnBtn.addEventListener('click', () => window.location.replace('#homepage'));
+  returnBtn.addEventListener('click', () => window.history.back());
 
   form.addEventListener('submit', (e) => {
     e.preventDefault();

--- a/src/pages/resetPassword/main.js
+++ b/src/pages/resetPassword/main.js
@@ -45,7 +45,7 @@ export default () => {
   const sendBtn = resetContainer.querySelector('#btn-reset-page');
   const resetMessage = resetContainer.querySelector('.reset-message');
 
-  returnBtn.addEventListener('click', () => window.location.replace('#homepage'));
+  returnBtn.addEventListener('click', () => window.history.back());
 
   sendBtn.addEventListener('click', (e) => {
     e.preventDefault();


### PR DESCRIPTION
a gente tem os botoes de retornar nas páginas about/login/register/resetpw, e tava usando o método replace pra voltar pra pagina homepage meio que de forma "forçada" (pq trocava a hash da url e assim nosso evento de hash dava load na pagina com aquela hash). 
eu troquei aqueles replaces por window.history.back(); o botao funciona da mesma forma - volta pra pagina anterior, como é o intuito do botao de retornar